### PR TITLE
feat: add Open Graph and Twitter Card meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,12 +20,6 @@
     <meta name="twitter:url" content="https://www.zenpool.space/" />
     <meta name="twitter:title" content="ZenPool | Listen to Bitcoin" />
     <meta name="twitter:description" content="Experience Bitcoin as ambient sound. Every transaction becomes a note, every block a singing bowl." />
-    <meta name="twitter:image" content="<IMAGE_URL_HERE>" />
-    
-    <!-- Open Graph image for social media previews -->
-    <meta property="og:image" content="<IMAGE_URL_HERE>" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
     
     <!-- Fonts: IBM Plex Mono for data, Outfit for headings -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary

Adds social media meta tags to `index.html` for better link previews when ZenPool is shared on social platforms.

## Changes

- Added Open Graph meta tags (`og:type`, `og:url`, `og:title`, `og:description`, `og:site_name`)
- Added Twitter Card meta tags (`twitter:card`, `twitter:url`, `twitter:title`, `twitter:description`)

## Why?

Currently when you share https://zenpool.space on Twitter, Discord, Slack, or other platforms, the link preview is minimal. With these meta tags, shared links will display:

- **Title**: ZenPool | Listen to Bitcoin
- **Description**: Experience Bitcoin as ambient sound. Every transaction becomes a note, every block a singing bowl.
- **Site name**: ZenPool

## Testing

You can validate the meta tags using:
- [Twitter Card Validator](https://cards-dev.twitter.com/validator)
- [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
- [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced site metadata to improve link previews and sharing by adding Open Graph and Twitter card meta tags (type, URL, title, description, site name, and card), enabling richer previews when pages are shared.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->